### PR TITLE
Fix error in split function

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@
  * @api private
  */
 module.exports = function required(port, protocol) {
-  protocol = protocol.split(':')[0];
+  protocol = protocol?.split(':')[0];
   port = +port;
 
   if (!port) return false;


### PR DESCRIPTION
if protocol params dont be string type it provide a syntax error